### PR TITLE
bug-erms-3246

### DIFF
--- a/documentation/CHANGELOG-TMP.md
+++ b/documentation/CHANGELOG-TMP.md
@@ -7,6 +7,8 @@
 
 **Ticket    Date    Branch  Version(current) Author  Feature/Bug     Description/Keywords**
 
+3246    19.03.2021  rc2.0   2.0.5       Andreas Bug         Meine Lizenzen lädt nur noch beidseitig belegte Verknüpfungen
+
 3239    19.03.2021  rc2.0   2.0.5       Andreas Bug         Filter erweitert und angepasst
 
 3238    19.03.2021  rc2.0   2.0.5       Andreas Bug         irrtümliche Selbstbenachrichtigung bei Kostenkopie-Änderung behoben

--- a/grails-app/services/de/laser/SubscriptionService.groovy
+++ b/grails-app/services/de/laser/SubscriptionService.groovy
@@ -130,7 +130,7 @@ class SubscriptionService {
         result.subscriptions = subscriptions.drop((int) result.offset).take((int) result.max)
         pu.setBenchmark('fetch licenses')
         if(subscriptions)
-            result.allLinkedLicenses = Links.findAllByDestinationSubscriptionInListAndLinkType(result.subscriptions,RDStore.LINKTYPE_LICENSE)
+            result.allLinkedLicenses = Links.findAllByDestinationSubscriptionInListAndSourceLicenseIsNotNullAndLinkType(result.subscriptions,RDStore.LINKTYPE_LICENSE)
         pu.setBenchmark('after licenses')
         List bm = pu.stopBenchmark()
         result.benchMark = bm


### PR DESCRIPTION
as of ERMS-3246, currentSubscriptions loads only links with source and destination set