### PR TITLE
bug-erms-3316

### DIFF
--- a/documentation/CHANGELOG-TMP.md
+++ b/documentation/CHANGELOG-TMP.md
@@ -7,7 +7,11 @@
 
 **Ticket    Date    Branch  Version(current) Author  Feature/Bug     Description/Keywords**
 
+33161   07.04.2021  rc2.0   2.0.6       Andreas Bug         Kindlizenzen konnten mit Elternverträgen verknüpft werden
+
 --      06.04.2021  rc2.0   2.0.6       Andreas Bug         Sync-Bugfix
+
+3312    06.04.2021  rc2.0   2.0.6       Andreas Bug         Ladequelle wurde nicht durchgereicht
 
 3302    01.04.2021  rc2.0   2.0.6       Andreas Bug         verschiedene Bugs im Pakettitelexport
 

--- a/grails-app/migrations/changelog-2021-04-07.groovy
+++ b/grails-app/migrations/changelog-2021-04-07.groovy
@@ -1,0 +1,14 @@
+databaseChangeLog = {
+
+    changeSet(author: "galffy (hand-coded)", id: "1617774040018-1") {
+        grailsChange {
+            change {
+                sql.execute("delete from links where l_id in ( select l_id from links join license l on l_source_lic_fk = lic_id join subscription on l_dest_sub_fk = sub_id where sub_parent_sub_fk is not null and lic_parent_lic_fk is null and exists ( select or_id from org_role where or_lic_fk = l_source_lic_fk and or_roletype_fk = (select rdv_id from refdata_value join refdata_category on rdv_owner = rdc_id where rdv_value = 'Licensing Consortium' and rdc_description = 'organisational.role') ) );")
+            }
+            rollback {
+
+            }
+        }
+    }
+
+}

--- a/grails-app/migrations/changelog.groovy
+++ b/grails-app/migrations/changelog.groovy
@@ -125,4 +125,5 @@ databaseChangeLog = {
     include file: 'changelog-2021-02-24.groovy'
     include file: 'changelog-2021-03-18.groovy'
 	include file: 'changelog-2021-03-24.groovy'
+	include file: 'changelog-2021-04-07.groovy'
 }

--- a/grails-app/services/de/laser/ctrl/SubscriptionControllerService.groovy
+++ b/grails-app/services/de/laser/ctrl/SubscriptionControllerService.groovy
@@ -521,7 +521,7 @@ class SubscriptionControllerService {
             result.members = Org.executeQuery(fsq.query, fsq.queryParams, params)
             result.members_disabled = Subscription.executeQuery("select oo.org.id from OrgRole oo join oo.sub s where s.instanceOf = :io",[io: result.subscription])
             result.validPackages = result.subscription.packages?.sort { it.pkg.name }
-            result.memberLicenses = License.executeQuery("select li.sourceLicense from Links li where li.destinationSubscription = :subscription and li.linkType = :linkType",[subscription:result.subscription, linkType:RDStore.LINKTYPE_LICENSE])
+            result.memberLicenses = License.executeQuery("select l from Links li join li.sourceLicense l where li.destinationSubscription = :subscription and li.linkType = :linkType and exists (select l2 from License l2 where l2.instanceOf = l)",[subscription:result.subscription, linkType:RDStore.LINKTYPE_LICENSE])
 
             [result:result,status:STATUS_OK]
         }
@@ -558,7 +558,7 @@ class SubscriptionControllerService {
                         }
                     }
                     if(params.generateSlavedLics == "all") {
-                        String query = "select li.sourceLicense from Links li where li.destinationSubscription = :subscription and li.linkType = :linkType"
+                        String query = "select l from License l where l.instanceOf in (select li.sourceLicense from Links li where li.destinationSubscription = :subscription and li.linkType = :linkType)"
                         licensesToProcess.addAll(License.executeQuery(query, [subscription:result.subscription, linkType:RDStore.LINKTYPE_LICENSE]))
                     }
                     else if(params.generateSlavedLics == "partial") {
@@ -1331,8 +1331,8 @@ class SubscriptionControllerService {
                 String addType = params.addType
                 if(!Package.findByGokbId(pkgUUID)) {
                     ApiSource apiSource = ApiSource.findByTypAndActive(ApiSource.ApiTyp.GOKBAPI, true)
-                    result.source = apiSource.baseUrl+apiSource.fixToken
-                    GlobalRecordSource source = GlobalRecordSource.findByUriLike(result.source)
+                    result.source = apiSource.baseUrl
+                    GlobalRecordSource source = GlobalRecordSource.findByUriLike(result.source+'%')
                     log.debug("linkPackage. Global Record Source URL: " +source.uri)
                     globalSourceSyncService.source = source
                     executorService.execute({
@@ -1341,7 +1341,7 @@ class SubscriptionControllerService {
                             globalSourceSyncService.defineMapFields()
                             Map<String,Object> queryResult = globalSourceSyncService.fetchRecordJSON(false,[componentType:'TitleInstancePackagePlatform',pkg:pkgUUID,max:5000])
 
-                            if(queryResult.records && queryResult.records.count > 0) {
+                            if(queryResult.records && queryResult.count > 0) {
                                 globalSourceSyncService.updateRecords(queryResult.records)
                             }else {
                                 globalSourceSyncService.createOrUpdatePackage(pkgUUID)


### PR DESCRIPTION
as of ERMS-3316, member subscriptions could be linked to parent licenses which has been prohibited; a cleanup changeset has been written which deletes such erroneously created links