### PR TITLE
bug-erms-3290

### DIFF
--- a/documentation/CHANGELOG-TMP.md
+++ b/documentation/CHANGELOG-TMP.md
@@ -7,7 +7,9 @@
 
 **Ticket    Date    Branch  Version(current) Author  Feature/Bug     Description/Keywords**
 
-33161   07.04.2021  rc2.0   2.0.6       Andreas Bug         Kindlizenzen konnten mit Elternverträgen verknüpft werden
+3316    07.04.2021  rc2.0   2.0.6       Andreas Bug         Kindlizenzen konnten mit Elternverträgen verknüpft werden
+
+3290    07.04.2021  rc2.0   2.0.6       Andreas Bug         Changeset zur Bereinigung falscher Lizenz-Vertrag-Verknüpfungen erstellt
 
 --      06.04.2021  rc2.0   2.0.6       Andreas Bug         Sync-Bugfix
 

--- a/grails-app/migrations/changelog-2021-04-07.groovy
+++ b/grails-app/migrations/changelog-2021-04-07.groovy
@@ -11,4 +11,15 @@ databaseChangeLog = {
         }
     }
 
+    changeSet(author: "galffy (hand-coded)", id: "1617774040018-2") {
+        grailsChange {
+            change {
+                sql.execute("DELETE FROM links WHERE l_link_type_rv_fk = (select rdv_id from refdata_value join refdata_category on rdv_owner = rdc_id where rdv_value = 'license' and rdc_description = 'link.type') and l_source_lic_fk is null")
+            }
+            rollback {
+
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
as of ERMS-3290, a cleanup changeset for subscription-license-links has been created which removes such links without a license