### PR TITLE
bug-erms-3697

### DIFF
--- a/documentation/CHANGELOG-TMP.md
+++ b/documentation/CHANGELOG-TMP.md
@@ -7,6 +7,8 @@
 
 **Ticket    Date    Branch  Version(current) Author  Feature/Bug     Description/Keywords**
 
+3697    23.07.2021  rc2.1   2.1.2       Andreas Bug         Umfragekosten waren nicht übertragbar, wenn mindestens eine Auftragsnummer belegt ist
+
 3647    02.07.2021  rc2.1   2.1.1       Andreas Feature     Icon für Anbieter eingeführt
 
 3646    01.07.2021  rc2.1   2.1.1       Andreas Feature     Unschärfe bei der Suche von Freitextmerkmalen aufgehoben

--- a/grails-app/controllers/de/laser/SurveyController.groovy
+++ b/grails-app/controllers/de/laser/SurveyController.groovy
@@ -3653,7 +3653,7 @@ class SurveyController {
                         copyCostItem.costInLocalCurrency = costItem.costInBillingCurrency
                     }
                     Org org = participantSub.getSubscriber()
-                    SurveyResult surveyResult = org ? SurveyResult.findBySurveyConfigAndParticipantAndType(result.surveyConfig, org, RDStore.SURVEY_PROPERTY_ORDER_NUMBER) : null
+                    SurveyResult surveyResult = org ? SurveyResult.findBySurveyConfigAndParticipantAndTypeAndStringValueIsNotNull(result.surveyConfig, org, RDStore.SURVEY_PROPERTY_ORDER_NUMBER) : null
 
                     if(surveyResult){
                         Order order = new Order(orderNumber: surveyResult.getValue(), owner: result.institution)


### PR DESCRIPTION
as of ERMS-3697, survey cost items were not transferrable when order numbers were in place