### PR TITLE
bug-erms-3790

### DIFF
--- a/documentation/CHANGELOG-TMP.md
+++ b/documentation/CHANGELOG-TMP.md
@@ -7,6 +7,8 @@
 
 **Ticket    Date    Branch  Version(current) Author  Feature/Bug     Description/Keywords**
 
+3790    10.09.2021  dev     2.2         Andreas Bug         Passwörter mit HTML-relevanten Zeichen wurden inkorrekt dargestellt
+
 3776    09.09.2021  dev     2.2         Moe     Feature     Lizenzverwaltung 
 
 3786    09.09.2021  dev     2.2         David   Feature     'Meine Workflows' überarbeiten

--- a/grails-app/views/mailTemplates/text/newPassword.gsp
+++ b/grails-app/views/mailTemplates/text/newPassword.gsp
@@ -6,7 +6,7 @@ ${serverURL}
 
 Benutzername: ${raw(user.username)}
 
-Passwort: ${newPass}
+Passwort: ${raw(newPass)}
 
 Sie können das Passwort im Nutzerprofil ändern.
 


### PR DESCRIPTION
as of ERMS-3790, resetted passwords were shown with HTML entities