### PR TITLE
bug-erms-3793

### DIFF
--- a/documentation/CHANGELOG-TMP.md
+++ b/documentation/CHANGELOG-TMP.md
@@ -7,6 +7,8 @@
 
 **Ticket    Date    Branch  Version(current) Author  Feature/Bug     Description/Keywords**
 
+3793    13.09.2021  dev     2.2         Andreas Bug         Merkmalswertlöschung bei Ja/Nein/Unbekannt angepasst 
+
 3792    13.09.2021  dev     2.2         Andreas Bug         fehlende Identifier-URL-Präfixes nachgetragen
 
 3791    13.09.2021  dev     2.2         Andreas Feature     Bestand, Umfrage und Workflow-Bubbles im Lizenzfinanzmenü nachgetragen

--- a/grails-app/controllers/de/laser/ajax/AjaxController.groovy
+++ b/grails-app/controllers/de/laser/ajax/AjaxController.groovy
@@ -1108,7 +1108,14 @@ class AjaxController {
                             members.each { m ->
                                 if(m[prop] instanceof Boolean)
                                     m.setProperty(prop, false)
-                                else m.setProperty(prop, null)
+                                else {
+                                    if(m[prop] instanceof RefdataValue) {
+                                        if(m[prop].owner.desc == RDConstants.Y_N_U)
+                                            m.setProperty(prop, RDStore.YNU_UNKNOWN)
+                                    }
+                                    else
+                                        m.setProperty(prop, null)
+                                }
                                 m.save()
                             }
                         }


### PR DESCRIPTION
as of ERMS-3793, refdata values could not be resetted after audit deletion if they are not nullable