### PR TITLE
bug-erms-4089

### DIFF
--- a/documentation/CHANGELOG-TMP.md
+++ b/documentation/CHANGELOG-TMP.md
@@ -7,6 +7,8 @@
 
 **Ticket    Date    Branch  Version(current) Author  Feature/Bug     Description/Keywords**
 
+4089    31.01.2022  rc-2.2  2.2.9       Andreas Bug         Fehlzuordnung Teilnehmervertrag-Lizenz bei Übertrag behoben
+
 4079    28.01.2022  rc-2.2  2.2.9       Moe     Bug         Titelumfrage: Titel können nicht nachträglich gelöscht werden von Konsortialstelle
 
 4083    27.01.2022  rc-2.2  2.2.9       Moe     Bug         Performance verbessern bei Teilnehmer verwalten (Merkmale)

--- a/grails-app/controllers/de/laser/SurveyController.groovy
+++ b/grails-app/controllers/de/laser/SurveyController.groovy
@@ -4259,7 +4259,7 @@ class SurveyController {
                 List<License> licensesToProcess = []
 
                 if(params.generateSlavedLics == "all") {
-                    String query = "select li.sourceLicense from Links li where li.destinationSubscription = :subscription and li.linkType = :linkType"
+                    String query = "select l from License l where l.instanceOf in (select li.sourceLicense from Links li where li.destinationSubscription = :subscription and li.linkType = :linkType)"
                     licensesToProcess.addAll(License.executeQuery(query, [subscription:newParentSub, linkType:RDStore.LINKTYPE_LICENSE]))
                 }
                 else if(params.generateSlavedLics == "partial") {


### PR DESCRIPTION
as of ERMS-4089, member subscriptions were falsely assigned to parent licenses upon renewal transfer